### PR TITLE
pin requirement versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-pyyaml
-pygithub
-dohq-artifactory
-slack_log_handler
-requests
+pyyaml==5.3.1
+pygithub==1.53
+dohq-artifactory==0.7.382
+slack_log_handler==0.3.0
+requests==2.24.0


### PR DESCRIPTION
Pinning versions so we can ensure consistency.

I've also enabled dependabot, so if new versions of any of the dependencies become available dependabot will automatically open a PR that is run through the tests for validation.