### PR TITLE
add support for formatted csv

### DIFF
--- a/operator_csv_libs/csv.py
+++ b/operator_csv_libs/csv.py
@@ -1,5 +1,13 @@
-import logging, sys, copy
+import logging, sys, copy, yaml
 from .images import Image
+
+class _literal(str):
+    pass
+
+
+def _literal_presenter(dumper, data):
+    return dumper.represent_scalar('tag:yaml.org,2002:str', data, style='|')
+
 
 class ClusterServiceVersion:
 
@@ -150,6 +158,13 @@ class ClusterServiceVersion:
         self._update_operand_images()
 
         return self.csv
+
+    def get_formatted_csv(self):
+        """ Returns a stringified save ready formatted ClusterServiceVersion
+            This allows maintaining the format of the 'alm-examples: |-' block
+        """
+        yaml.add_representer(_literal, _literal_presenter)
+        return yaml.dump(self.get_updated_csv(), default_flow_style=False)
 
     def get_replaces(self):
         """ Return String

--- a/operator_csv_libs/tests/csv_test.py
+++ b/operator_csv_libs/tests/csv_test.py
@@ -481,6 +481,21 @@ class TestCSV(unittest.TestCase):
         ## Assert that original CSV did not get changed at all
         self.assertEqual(c.csv, c.original_csv)
 
+    def test__get_formatted_csv(self):
+        # Read in sample files
+        with open(THIS_DIR + '/test_files/valid_csv_formatted.yaml', 'r') as stream:
+            csv_sample = yaml.safe_load(stream)
+
+        c = ClusterServiceVersion(csv_sample)
+
+        # Increasing the maxdiff lets us see all the context on how the yaml failed
+        self.maxDiff = None
+
+        # Ensure that data has not been changed
+        self.assertDictEqual(yaml.safe_load(c.get_formatted_csv()), csv_sample)
+
+        # Ensure that format has been maintained
+        self.assertEqual(c.get_formatted_csv(), yaml.dump(csv_sample, default_flow_style=False))
 
     def test__setup_basic_logger(self):
         # should not be tested because it only sets up logger

--- a/operator_csv_libs/tests/test_files/valid_csv_formatted.yaml
+++ b/operator_csv_libs/tests/test_files/valid_csv_formatted.yaml
@@ -1,0 +1,479 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "orchestrator.management.ibm.com/v1alpha1",
+          "kind": "Installation",
+          "metadata": {
+            "name": "ibm-management"
+          },
+          "spec": {
+            "storageClass": "",
+            "imagePullSecret": "ibm-management-pull-secret",
+            "license": {
+              "accept": false
+            },
+            "mcmCoreDisabled": false,
+            "pakModules": [
+              {
+                "config": [
+                  {
+                    "enabled": true,
+                    "name": "ibm-management-im-install",
+                    "spec": {}
+                  },
+                  {
+                    "enabled": true,
+                    "name": "ibm-management-infra-grc",
+                    "spec": {}
+                  },
+                  {
+                    "enabled": true,
+                    "name": "ibm-management-infra-vm",
+                    "spec": {}
+                  },
+                  {
+                    "enabled": true,
+                    "name": "ibm-management-cam-install",
+                    "spec": {}
+                  },
+                  {
+                    "enabled": true,
+                    "name": "ibm-management-service-library",
+                    "spec": {}
+                  }
+                ],
+                "enabled": false,
+                "name": "infrastructureManagement"
+              },
+              {
+                "config": [
+                  {
+                    "enabled": true,
+                    "name": "ibm-management-monitoring",
+                    "spec": {
+                       "operandRequest": {},
+                       "monitoringDeploy": {
+                         "global": {
+                           "environmentSize": "size0",
+                           "persistence": {
+                             "storageClassOption": {
+                               "cassandrabak": "none",
+                               "cassandradata": "default",
+                               "couchdbdata": "default",
+                               "datalayerjobs": "default",
+                               "elasticdata": "default",
+                               "kafkadata": "default",
+                               "zookeeperdata": "default"
+                             },
+                             "storageSize": {
+                               "cassandrabak": "50Gi",
+                               "cassandradata": "50Gi",
+                               "couchdbdata": "5Gi",
+                               "datalayerjobs": "5Gi",
+                               "elasticdata": "5Gi",
+                               "kafkadata": "25Gi",
+                               "zookeeperdata": "1Gi"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                ],
+                "enabled": false,
+                "name": "monitoring"
+              },
+              {
+                "config": [
+                  {
+                    "enabled": true,
+                    "name": "ibm-management-notary",
+                    "spec": {}
+                  },
+                  {
+                    "enabled": true,
+                    "name": "ibm-management-image-security-enforcement",
+                    "spec": {}
+                  },
+                  {
+                    "enabled": false,
+                    "name": "ibm-management-mutation-advisor",
+                    "spec": {}
+                  },
+                  {
+                    "enabled": false,
+                    "name": "ibm-management-vulnerability-advisor",
+                    "spec": {
+                      "controlplane": {
+                        "esSecurityEnabled": true,
+                        "esServiceName": "elasticsearch.ibm-common-services",
+                        "esSecretName": "logging-elk-certs",
+                        "esSecretCA": "ca.crt",
+                        "esSecretCert": "curator.crt",
+                        "esSecretKey": "curator.key"
+                      },
+                      "annotator": {
+                        "esSecurityEnabled": true,
+                        "esServiceName": "elasticsearch.ibm-common-services",
+                        "esSecretName": "logging-elk-certs",
+                        "esSecretCA": "ca.crt",
+                        "esSecretCert": "curator.crt",
+                        "esSecretKey": "curator.key"
+                      },
+                      "indexer": {
+                        "esSecurityEnabled": true,
+                        "esServiceName": "elasticsearch.ibm-common-services",
+                        "esSecretName": "logging-elk-certs",
+                        "esSecretCA": "ca.crt",
+                        "esSecretCert": "curator.crt",
+                        "esSecretKey": "curator.key"
+                      }
+                    }
+                  }
+                ],
+                "enabled": false,
+                "name": "securityServices"
+              },
+              {
+                "config": [
+                  {
+                    "enabled": true,
+                    "name": "ibm-management-sre-chatops",
+                    "spec": {}
+                  }
+                ],
+                "enabled": false,
+                "name": "operations"
+              },
+              {
+                "config": [
+                  {
+                    "enabled": true,
+                    "name": "ibm-management-manage-runtime",
+                    "spec": {}
+                  }
+                ],
+                "enabled": false,
+                "name": "techPreview"
+              }
+            ]
+          }
+        }
+      ]
+
+    capabilities: Basic Install
+    olm.skipRange: <2.1.1-202009111050
+  labels:
+    operatorframework.io/arch.amd64: supported
+    operatorframework.io/arch.ppc64le: supported
+    operatorframework.io/os.linux: supported
+  name: ibm-management-orchestrator.v2.1.1
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+    - description: Installation is the Schema for the installations API
+      displayName: Installation
+      kind: Installation
+      name: installations.orchestrator.management.ibm.com
+      specDescriptors:
+      - description: License agreement http://ibm.biz/cp4mcm-20-license must be accepted
+          during install of this product.
+        displayName: License Acceptance
+        path: license.accept
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+        - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Cloud_Pak_for_Multicloud_Management
+      - description: ImagePullSecret is the image pull secret to use while installing
+          the Cloud Pak
+        displayName: Image Pull Secret
+        path: imagePullSecret
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes:Secret
+        - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Cloud_Pak_for_Multicloud_Management
+      - description: StorageClass is the name of the storage class to use while installing
+          the Cloud Pak
+        displayName: Storage Class
+        path: storageClass
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes:StorageClass
+        - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Cloud_Pak_for_Multicloud_Management
+      - description: McmCoreDisabled is the boolean toggle for disabling the default
+          multicloud management functions and using Red Hat Advanced Container Management
+        displayName: Multicloud Management Core Disabled
+        path: mcmCoreDisabled
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+        - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Cloud_Pak_for_Multicloud_Management
+      version: v1alpha1
+    required:
+    - description: IBM Cloud Platform Common Services API
+      displayName: CommonService
+      kind: CommonService
+      name: commonservices.operator.ibm.com
+      version: v3
+  description: "The IBM Cloud Pak for Multicloud Management, running on Red Hat OpenShift,\
+    \ provides consistent visibility, governance, and automation from on premises\
+    \ to the edge. Enterprises gain capabilities such as multicluster management,\
+    \ event management, application performance management, infrastructure management,\
+    \ and existing tools management.\n\n\nWith IBM Cloud Pak for Multicloud Management,\
+    \ you get more application and cluster visibility across the enterprise to any\
+    \ public or private cloud. You can improve automation by simplifying your IT and\
+    \ application operations management with increased flexibility and cost savings,\
+    \ and intelligent data analysis driven by predictive signals.\n\n\nYou can also\
+    \ take advantage of the governance with this IBM Cloud Pak for Multicloud Management\
+    \ because you can manage your multicloud environments with a consistent and automated\
+    \ set of configuration and security policies across all applications and clusters.\n\
+    \n\n\n## Supported platforms \n\n Red Hat OpenShift Container Platform 4.3.22\
+    \ or newer, and 4.4.4 or newer, installed on one of the following platforms: \n\
+    - Linux x86_64\n\n## Prerequisites \n\n Before you install this operator, you\
+    \ need to complete the prerequisites. \n- For more information, see the IBM Knowledge\
+    \ Center [IBM Cloud Pak for Multicloud Management documentation](https://www.ibm.com/support/knowledgecenter/SSFC4F_2.0.0/install/prep.html).\n\
+    \n## Documentation \n\n To install the operator, follow the the installation and\
+    \ configuration instructions within the IBM Knowledge Center.\n \n- See the documentation\
+    \ for [IBM Cloud Pak for Multicloud Management](https://www.ibm.com/support/knowledgecenter/en/SSFC4F_2.0.0/install/overview.html)"
+  displayName: IBM Cloud Pak for Multicloud Management
+  icon:
+  - base64data: PHN2ZyBpZD0iTGF5ZXJfMSIgZGF0YS1uYW1lPSJMYXllciAxIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB2aWV3Qm94PSIwIDAgMzIgMzIiPjxkZWZzPjxzdHlsZT4uY2xzLTF7ZmlsbDojZmZmO30uY2xzLTJ7ZmlsbDp1cmwoI2xpbmVhci1ncmFkaWVudCk7fS5jbHMtM3ttYXNrOnVybCgjbWFzayk7fS5jbHMtNHtmaWxsOnVybCgjbGluZWFyLWdyYWRpZW50LTIpO30uY2xzLTV7ZmlsbDojMDAxZDZjO308L3N0eWxlPjxsaW5lYXJHcmFkaWVudCBpZD0ibGluZWFyLWdyYWRpZW50IiB4MT0iMjgiIHkxPSIyMiIgeDI9IjI4IiB5Mj0iMTEiIGdyYWRpZW50VW5pdHM9InVzZXJTcGFjZU9uVXNlIj48c3RvcCBvZmZzZXQ9IjAiIHN0b3Atb3BhY2l0eT0iMCIvPjxzdG9wIG9mZnNldD0iMC45Ii8+PC9saW5lYXJHcmFkaWVudD48bWFzayBpZD0ibWFzayIgeD0iMCIgeT0iMCIgd2lkdGg9IjMyIiBoZWlnaHQ9IjMyIiBtYXNrVW5pdHM9InVzZXJTcGFjZU9uVXNlIj48cGF0aCBjbGFzcz0iY2xzLTEiIGQ9Ik0xNiwzMWEuOS45LDAsMCwxLS41LS4xNGwtMTItN0ExLDEsMCwwLDEsMywyM1Y5YTEsMSwwLDAsMSwuNS0uODZsMTItN2ExLDEsMCwwLDEsMSwwbDEyLDctMSwxLjcyTDE2LDMuMTYsNSw5LjU3VjIyLjQzbDExLDYuNDEsMTEtNi40MVYxMmgyVjIzYTEsMSwwLDAsMS0uNS44NmwtMTIsN0EuOS45LDAsMCwxLDE2LDMxWiIvPjxyZWN0IGNsYXNzPSJjbHMtMiIgeD0iMjYiIHk9IjExIiB3aWR0aD0iNCIgaGVpZ2h0PSIxMSIvPjwvbWFzaz48bGluZWFyR3JhZGllbnQgaWQ9ImxpbmVhci1ncmFkaWVudC0yIiB4MT0iLTYwNDkuMyIgeTE9Ii0yMjA1LjMiIHgyPSItNjAxNy4zIiB5Mj0iLTIyMzcuMyIgZ3JhZGllbnRUcmFuc2Zvcm09Im1hdHJpeCgxLCAwLCAwLCAtMSwgNjA0OS4zLCAtMjIwNS4zKSIgZ3JhZGllbnRVbml0cz0idXNlclNwYWNlT25Vc2UiPjxzdG9wIG9mZnNldD0iMC4xIiBzdG9wLWNvbG9yPSIjMDhiZGJhIi8+PHN0b3Agb2Zmc2V0PSIwLjkiIHN0b3AtY29sb3I9IiMwZjYyZmUiLz48L2xpbmVhckdyYWRpZW50PjwvZGVmcz48dGl0bGU+Q1A0TUNNX09wZXJhdG9yczwvdGl0bGU+PGcgY2xhc3M9ImNscy0zIj48cmVjdCBpZD0iQ29sb3IiIGNsYXNzPSJjbHMtNCIgd2lkdGg9IjMyIiBoZWlnaHQ9IjMyIiB0cmFuc2Zvcm09InRyYW5zbGF0ZSgwIDMyKSByb3RhdGUoLTkwKSIvPjwvZz48cGF0aCBjbGFzcz0iY2xzLTUiIGQ9Ik0yMSwxOWEyLjA5LDIuMDksMCwwLDAtLjUxLjA3bC0xLjc4LTEuNzgsMCwwYTIuODgsMi44OCwwLDAsMCwwLTIuNjRsMCwwLDEuNzgtMS43OEEyLjA5LDIuMDksMCwwLDAsMjEsMTNhMiwyLDAsMSwwLTItMiwyLjA5LDIuMDksMCwwLDAsLjA3LjUxbC0xLjc4LDEuNzgsMCwwYTIuODgsMi44OCwwLDAsMC0yLjY0LDBsMCwwLTEuNzgtMS43OEEyLjA5LDIuMDksMCwwLDAsMTMsMTFhMiwyLDAsMSwwLTIsMiwyLjA5LDIuMDksMCwwLDAsLjUxLS4wN2wxLjc4LDEuNzgsMCwwYTIuODgsMi44OCwwLDAsMCwwLDIuNjRsMCwwLTEuNzgsMS43OEEyLjA5LDIuMDksMCwwLDAsMTEsMTlhMiwyLDAsMSwwLDIsMiwyLjA5LDIuMDksMCwwLDAtLjA3LS41MWwxLjc4LTEuNzgsMCwwYTIuODgsMi44OCwwLDAsMCwyLjY0LDBsMCwwLDEuNzgsMS43OEEyLjA5LDIuMDksMCwwLDAsMTksMjFhMiwyLDAsMSwwLDItMlptLTUtMmExLDEsMCwxLDEsMS0xQTEsMSwwLDAsMSwxNiwxN1oiLz48L3N2Zz4=
+    mediatype: image/svg+xml
+  install:
+    spec:
+      clusterPermissions:
+      - rules:
+        - apiGroups:
+          - ''
+          resources:
+          - pods
+          - services
+          - services/finalizers
+          - endpoints
+          - persistentvolumeclaims
+          - namespaces
+          - events
+          - configmaps
+          - secrets
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - daemonsets
+          - replicasets
+          - statefulsets
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - servicemonitors
+          verbs:
+          - get
+          - create
+        - apiGroups:
+          - operators.coreos.com
+          resources:
+          - catalogsources
+          - subscriptions
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - apps
+          resourceNames:
+          - ibm-management-orchestrator
+          resources:
+          - deployments/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - ''
+          resources:
+          - pods
+          verbs:
+          - get
+        - apiGroups:
+          - apps
+          resources:
+          - replicasets
+          - deployments
+          verbs:
+          - get
+        - apiGroups:
+          - operator.ibm.com
+          resources:
+          - '*'
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - orchestrator.management.ibm.com
+          resources:
+          - '*'
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - security.openshift.io
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - use
+          - watch
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - roles
+          - rolebindings
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - storage.k8s.io
+          resources:
+          - storageclasses
+          verbs:
+          - get
+          - list
+          - watch
+        serviceAccountName: ibm-management-orchestrator
+      deployments:
+      - name: ibm-management-orchestrator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: ibm-management-orchestrator
+          strategy: {}
+          template:
+            metadata:
+              annotations:
+                cloudpakId: 7f6eda41081c4e08a255be1f0b4aef2d
+                cloudpakName: IBM Cloud Pak for Multicloud Management
+                cloudpakVersion: '2.1'
+                olm.relatedImage.cp4mcm-catalog: cp.icr.io/cp/cp4mcm/cp4mcm-operator-catalog@sha256:b2aeba0e620b4325bda303af3024e7dafc809dd637ca99c50788a3d6a0e6234f
+                productChargedContainers: All
+                productCloudpakRatio: '1:1'
+                productID: 74394a3a4a81449f9c7c81403d09dca3
+                productMetric: MANAGED_VIRTUAL_SERVER
+                productName: IBM Cloud Pak for Multicloud Management Orchestrator
+                productVersion: '2.1'
+              labels:
+                name: ibm-management-orchestrator
+                app.kubernetes.io/name: ibm-management-orchestrator
+                app.kubernetes.io/instance: ibm-management-orchestrator
+                app.kubernetes.io/managed-by: ibm-management-orchestrator
+            spec:
+              affinity:
+                nodeAffinity:
+                  requiredDuringSchedulingIgnoredDuringExecution:
+                    nodeSelectorTerms:
+                    - matchExpressions:
+                      - key: beta.kubernetes.io/arch
+                        operator: In
+                        values:
+                        - amd64
+                        - ppc64le
+              containers:
+              - command:
+                - ibm-management-orchestrator
+                env:
+                - name: WATCH_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['olm.targetNamespaces']
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: OPERATOR_NAME
+                  value: ibm-management-orchestrator
+                - name: INITIAL_CATALOG
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['olm.relatedImage.cp4mcm-catalog']
+                image: quay.io/cp4mcm/ibm-management-orchestrator@sha256:9c1840496d49b95a1d02a44cc0269f6a4a0bcec2711eda9812da9dd8b0fa6990
+                imagePullPolicy: IfNotPresent
+                name: ibm-management-orchestrator
+                resources:
+                  limits:
+                    cpu: 100m
+                    memory: 256Mi
+                  requests:
+                    cpu: 100m
+                    memory: 128Mi
+                securityContext:
+                  allowPrivilegeEscalation: false
+                  capabilities:
+                    drop:
+                    - ALL
+                  privileged: false
+                  readOnlyRootFilesystem: true
+                  runAsNonRoot: true
+              imagePullSecrets:
+              - name: ibm-management-pull-secret
+              serviceAccountName: ibm-management-orchestrator
+    strategy: deployment
+  installModes:
+  - supported: false
+    type: OwnNamespace
+  - supported: false
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: true
+    type: AllNamespaces
+  keywords:
+  - cp4mcm
+  maintainers:
+  - email: IBM.Cloud.Pak.for.Multicloud.Management@it.ibm.com
+    name: IBM Cloud Pak for Multicloud Management Support
+  maturity: alpha
+  provider:
+    name: IBM
+  relatedImages:
+  - image: cp.icr.io/cp/cp4mcm/cp4mcm-operator-catalog@sha256:b2aeba0e620b4325bda303af3024e7dafc809dd637ca99c50788a3d6a0e6234f
+    name: cp4mcm-catalog
+  version: 2.1.1


### PR DESCRIPTION
Currently `csv.get_updated_csv()` upsets the formatting of `metadata.annotations.alm-examples` since yaml.dump by default converts blocks into a single string.

This new method fixes this by adding a representer to yaml.

On the consumption side `csv.get_formatted_csv()` can be written directly to file or github, removing the need to run it through `yaml.dump()`