### PR TITLE
fix python environment upload to quay github action

### DIFF
--- a/.github/workflows/python-env-upload.yml
+++ b/.github/workflows/python-env-upload.yml
@@ -53,7 +53,7 @@ jobs:
         with:
           context: .
           file: ./docker/Dockerfile
-          platforms: linux/amd64, linux/ppc64le
+          platforms: linux/amd64,linux/ppc64le
           push: ${{ github.event_name != 'pull_request' }}
           tags: |
             ${{ steps.prepare.outputs.tags }}


### PR DESCRIPTION
The issue seems to be coming from a recent change that was made to the github action buildx, which doesn't parse the platforms tag to remove any whitespace, instead it has be done from the users end.