### PR TITLE
ensure quay images are identified only by actual domain

### DIFF
--- a/operator_csv_libs/imagerepo.py
+++ b/operator_csv_libs/imagerepo.py
@@ -13,7 +13,7 @@ class ImageRepo:
         # Check for some well known repos
         if 'artifactory' in self.image.get_image_repo():
             self.image_repo = ArtifactoryRepo(self.image)
-        elif 'quay.io' in self.image.get_image_repo():
+        elif self.image.get_image_repo().startswith('quay.io/'):
             self.image_repo = QuayRepo(self.image)
 
         else:

--- a/operator_csv_libs/tests/imagerepo_test.py
+++ b/operator_csv_libs/tests/imagerepo_test.py
@@ -69,6 +69,15 @@ class TestImageRepo(unittest.TestCase):
         # check to see that digest is returned
         self.assertEqual(self.artifactoryImgRepoWithOsAuthentication.get_image_digest(), 'sha256:dummy_sha')
 
+class TestImageRepoQuayImage(unittest.TestCase):
+    def setUp(self):
+        self.quayImgWithDigest = Image(IMG_NAME, QUAY_IMAGE_WITH_DIGEST, DEPLOYMENT, CONTAINER)
+        # Initialize a general ImageRepo
+        self.quayImgRepo = ImageRepo(self.quayImgWithDigest)
+
+    def test_init(self):
+        # check quay images are identified correctly
+        self.assertIsInstance(self.quayImgRepo.image_repo, QuayRepo)
 
 class TestArtifactoryRepo(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
Update the way quay.io images are identified. 
This should fix this complaint: https://github.com/multicloud-ops/operator-csv-libs/security/code-scanning/1?query=ref%3Arefs%2Fheads%2Fmaster

Also added relevant extra test case for ImageRepo 