### PR TITLE
Fix get_formatted_csv function and unit testing

### DIFF
--- a/operator_csv_libs/csv.py
+++ b/operator_csv_libs/csv.py
@@ -170,7 +170,9 @@ class ClusterServiceVersion:
             This allows maintaining the format of the `alm-examples: |-` block
         """
         yaml.add_representer(_literal, _literal_presenter)
-        return yaml.dump(self.get_updated_csv(), default_flow_style=False)
+        formatted_csv = self.get_updated_csv()
+        formatted_csv['metadata']['annotations']['alm-examples'] = _literal(formatted_csv['metadata']['annotations']['alm-examples'])
+        return yaml.dump(formatted_csv, default_flow_style=False)
 
     def get_replaces(self):
         """ Return String

--- a/operator_csv_libs/tests/csv_test.py
+++ b/operator_csv_libs/tests/csv_test.py
@@ -2,7 +2,7 @@ import unittest
 import pytest
 import copy
 import os, yaml
-from ..csv import ClusterServiceVersion
+from ..csv import ClusterServiceVersion, _literal, _literal_presenter
 from ..images import Image
 
 THIS_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -503,6 +503,10 @@ class TestCSV(unittest.TestCase):
     def test__get_formatted_csv(self):
         # Read in sample files
         with open(THIS_DIR + '/test_files/valid_csv_formatted.yaml', 'r') as stream:
+            csv_sample_formatted = yaml.safe_load(stream)
+        
+        # Read in sample files
+        with open(THIS_DIR + '/test_files/valid_csv.yaml', 'r') as stream:
             csv_sample = yaml.safe_load(stream)
 
         c = ClusterServiceVersion(csv_sample)
@@ -511,10 +515,12 @@ class TestCSV(unittest.TestCase):
         self.maxDiff = None
 
         # Ensure that data has not been changed
-        self.assertDictEqual(yaml.safe_load(c.get_formatted_csv()), csv_sample)
+        self.assertDictEqual(yaml.safe_load(c.get_formatted_csv()), csv_sample_formatted)
 
         # Ensure that format has been maintained
-        self.assertEqual(c.get_formatted_csv(), yaml.dump(csv_sample, default_flow_style=False))
+        yaml.add_representer(_literal, _literal_presenter)
+        csv_sample_formatted['metadata']['annotations']['alm-examples'] = _literal(csv_sample_formatted['metadata']['annotations']['alm-examples'])
+        self.assertEqual(c.get_formatted_csv(), yaml.dump(csv_sample_formatted, default_flow_style=False))
 
     def test__setup_basic_logger(self):
         # should not be tested because it only sets up logger

--- a/operator_csv_libs/tests/test_files/valid_csv.yaml
+++ b/operator_csv_libs/tests/test_files/valid_csv.yaml
@@ -309,6 +309,9 @@ spec:
                 productVersion: '2.1'
               labels:
                 name: ibm-management-orchestrator
+                app.kubernetes.io/name: ibm-management-orchestrator
+                app.kubernetes.io/instance: ibm-management-orchestrator
+                app.kubernetes.io/managed-by: ibm-management-orchestrator
             spec:
               affinity:
                 nodeAffinity:

--- a/operator_csv_libs/tests/test_files/valid_csv_formatted.yaml
+++ b/operator_csv_libs/tests/test_files/valid_csv_formatted.yaml
@@ -164,7 +164,6 @@ metadata:
           }
         }
       ]
-
     capabilities: Basic Install
     olm.skipRange: <2.1.1-202009111050
   labels:

--- a/operator_csv_libs/tests/test_files/valid_operator_deployment.yaml
+++ b/operator_csv_libs/tests/test_files/valid_operator_deployment.yaml
@@ -23,6 +23,9 @@ spec:
         productVersion: '2.1'
       labels:
         name: ibm-management-orchestrator
+        app.kubernetes.io/name: ibm-management-orchestrator
+        app.kubernetes.io/instance: ibm-management-orchestrator
+        app.kubernetes.io/managed-by: ibm-management-orchestrator
     spec:
       affinity:
         nodeAffinity:


### PR DESCRIPTION
The previous implementation was not formatting the CSV. I went ahead and reassigned the alm-example string as the literal class and followed the same logic when writing the unit test to verify the dictionary and format was accurate.