### PR TITLE
Add operator catalog object and enhance catalog object, add unit tests

### DIFF
--- a/operator_csv_libs/catalog.py
+++ b/operator_csv_libs/catalog.py
@@ -23,64 +23,127 @@ class CatalogError(Exception):
 Class for interacting with File based Catalog files
 '''
 class Catalog:
-
+    #Constructor function for the Catalog class
     def __init__(self, file, indent=4):
+        #Initialize some class variables for the Catalog class
         self.channels = []
         self.package = ''
         self.bundles = []
         self.indent = indent
 
+        #If the provided path does not exist, then raise an exception
         if not os.path.exists(file):
-            raise CatalogError(f"Cannot find catalog.json file {file}")
+            raise CatalogError(f"Catalog path does not exist: {file}")
 
-        # Read in data from single catalog file
+        #Read in catalog data from a single catalog file, formatted as a json stream
         if os.path.isfile(file):
-            with open(file) as stream:
-                separators = []
-                lines = stream.readlines()
-                count = 0
-                startValue = 0
-                for line in lines:
-                    if line == '}\n' or line == '}':
-                        separators.append(count)
-                    count += 1
-                for s in separators:
-                    data = json.loads(''.join(lines[startValue:s+1]))
-                    if 'schema' not in data:
-                        raise CatalogError(f"Cannot find a schema value in {data}")
-
-                    if data['schema'] == 'olm.package':
-                        if self.package != '':
-                            raise CatalogError(f"Found 2 packages in a single file, unexpected use case. Please update the code base")
-                        self.package = data
-                    elif data['schema'] == 'olm.channel':
-                        self.channels.append(data)
-                    elif data['schema'] == 'olm.bundle':
-                        self.bundles.append(data)
-
-                    startValue = s+1
-        # Read in data from a directory of json files
+            self._load_catalog_from_json_stream_file(file)
+        #Read in data from a directory of json files
         elif os.path.isdir(file):
-            for f in os.listdir(file):
-                with open(f"{file}/{f}") as stream:
-                    data = json.load(stream)
-                    if 'schema' not in data:
-                        raise CatalogError(f"Cannot find a schema value in {data}")
+            self._load_catalog_from_directory(file)
 
-                    if data['schema'] == 'olm.package':
-                        if self.package != '':
-                            raise CatalogError(f"Found 2 packages in a single file, unexpected use case. Please update the code base")
-                        self.package = data
-                    elif data['schema'] == 'olm.channel':
-                        self.channels.append(data)
-                    elif data['schema'] == 'olm.bundle':
-                        self.bundles.append(data)
+    #Load the Catalog object using a single json stream file
+    def _load_catalog_from_json_stream_file(self, file):
+        #Note that the catalog.json file is expected to be formatted as a json stream
+        with open(file) as stream:
+            #Initialize some variables for reading the json stream
+            separators = []
+            lines = stream.readlines()
+            count = 0
+            startValue = 0
+
+            #Loop through the lines in the file and determine the length in lines of each json object
+            for line in lines:
+                if line == '}\n' or line == '}':
+                    separators.append(count)
+                count += 1
+
+            #Use the length readings from above to loop back through and read in each json object
+            for s in separators:
+                #Load the nth json object
+                data = json.loads(''.join(lines[startValue:s+1]))
+
+                #Sanity check whether there is an olm schema value, if not then the json is invalid
+                if 'schema' not in data:
+                    raise CatalogError(f"Cannot find a schema value in {data}")
+
+                #Read in the olm package object
+                if data['schema'] == 'olm.package':
+                    #Sanity check whether there are multiple packages, if so then this is invalid json
+                    if self.package != '':
+                        raise CatalogError(f"There are multiple package objects in your catalog file, but only one is expected.")
+                    #Store the package object
+                    self.package = data
+                #Read in an olm channel object
+                elif data['schema'] == 'olm.channel':
+                    self.channels.append(data)
+                #Read in an olm bundle object
+                elif data['schema'] == 'olm.bundle':
+                    self.bundles.append(data)
+
+                #Increment the start value function to the initial line index of the next json object
+                startValue = s+1
+    
+    #Load the Catalog object using multiple catalog files in a single directory
+    def _load_catalog_from_directory(self, directory):
+        #Loop through the files in the directory
+        for file in os.listdir(directory):
+            #Open each file
+            with open(f"{directory}/{file}") as json_object:
+                #Load the json from the file
+                data = json.load(json_object)
+
+                #Sanity check whether there is an olm schema value, if not then the json is invalid
+                if 'schema' not in data:
+                    raise CatalogError(f"Cannot find a schema value in {data}")
+
+                #Read in the olm package object
+                if data['schema'] == 'olm.package':
+                    #Sanity check whether there are multiple packages, if so then this is invalid json
+                    if self.package != '':
+                        raise CatalogError(f"Found 2 packages in a single file, unexpected use case. Please update the code base")
+                    #Store the package object
+                    self.package = data
+                #Read in an olm channel object
+                elif data['schema'] == 'olm.channel':
+                    self.channels.append(data)
+                #Read in an olm bundle object
+                elif data['schema'] == 'olm.bundle':
+                    self.bundles.append(data)
 
     def get_channels(self):
         return self.channels
+    
+    #Get all channels matching a provided substring
+    def get_channels_by_substring(self, substring):
+        #Initialize a list of channels matching the substring
+        channels_matching_substring = []
 
+        #Loop through all the channels
+        for channel in self.channels:
+            #If the substring belongs to the channel name string, then include it
+            if substring in channel['name']:
+                channels_matching_substring.append(channel)
+        
+        #Return the list of channels matching the substring
+        return channels_matching_substring
+    
     def get_bundles(self):
         return self.bundles
+
+    #Get all bundles matching a provided substring
+    def get_bundles_by_substring(self, substring):
+        #Initialize a list of bundles matching the substring
+        bundles_matching_substring = []
+
+        #Loop through all the bundles
+        for bundle in self.bundles:
+            #If the substring belongs to the bundle name string, then include it
+            if substring in bundle['name']:
+                bundles_matching_substring.append(bundle)
+        
+        #Return the list of bundles matching the substring
+        return bundles_matching_substring
 
     def get_default_channel(self):
         return self.package['defaultChannel']
@@ -154,3 +217,121 @@ class Catalog:
             ret += f"\tChannel: {c['name']}\tLatest entry: {self.get_latest_channel_entry(c)}\n"
         return ret
 
+'''
+Class for interacting with file-based operator catalogs with many operators
+'''
+class OperatorCatalog:
+    #Constructor for the OperatorCatalog class
+    def __init__(self, path):
+        #Initialize some class variables for the OperatorCatalog class
+        self.catalogs = {}
+
+        #Sanity check to ensure that the path to the operator catalog exists
+        if not os.path.exists(path):
+            raise CatalogError(f"Operator catalog path does not exist: {path}")
+        
+        #If the operator catalog path does exist, then loop through its subdirectories
+        for subdirectory in os.listdir(path):
+            if os.path.isdir(subdirectory):
+                self.add_catalog_from_directory(f"{path}/{subdirectory}")
+    
+    #Add a new catalog into the operator catalog by loading it from a file
+    def add_catalog_from_file(self, path):
+        #Sanity check whether the provided path is a file
+        if not os.path.isfile(path):
+            raise CatalogError(f"The catalog path is not a file: {path}")
+        
+        #Load the file into a Catalog object
+        #If any errors occur an exception will by thrown by the Catalog object constructor
+        catalog = Catalog(path)
+
+        #Sanity check whether the operator name already exists
+        if catalog.package['name'] in self.catalogs.keys():
+            raise CatalogError(f"Catalog already exists: {catalog.package['name']}")
+        
+        #Add the catalog to the operator catalog
+        self.catalogs[catalog.package['name']] = catalog
+
+    #Add a new catalog into the operator catalog by loading it from a directory
+    def add_catalog_from_directory(self, path):
+        #Sanity check whether the provided path is a directory
+        if not os.path.isdir(path):
+            raise CatalogError(f"The catalog path is not a directory: {path}")
+        
+        #Load the directory into a Catalog object
+        #If any errors occur, an exception will be thrown by the Catalog object constructor
+        catalog = Catalog(path)
+
+        #Sanity check whether the operator name already exists
+        if catalog.package['name'] in self.catalogs.keys():
+            raise CatalogError(f"Catalog already exists: {catalog.package['name']}")
+
+        #Add the catalog to the operator catalog under the operator name found/provided
+        self.catalogs[catalog.package['name']] = catalog
+            
+    
+    #Get the operator-to-catalog mapping from the catalog object
+    def get_catalogs(self):
+        return self.catalogs
+    
+    #Get a subset of the catalogs whose operator names match a provided substring
+    def get_catalogs_by_substring(self, substring):
+        #Initialize a dict to store the results
+        catalogs_by_substring = {}
+
+        #Loop through the operator names and determine which operator names match the provided substring
+        for operator_name in self.catalogs.keys():
+            if substring in operator_name:
+               catalogs_by_substring[operator_name] = self.catalogs[operator_name]
+
+        #Return the dict storing the results
+        return catalogs_by_substring
+    
+    #Get a particular catalog whose operator name matches the one provided
+    def get_catalog(self, operator_name):
+        #Sanity check whether the catalog exists for the provided operator name
+        if operator_name in self.catalogs.keys():
+            raise CatalogError(f"Catalog not found for operator {operator_name}")
+        
+        #Return the catalog
+        return self.catalogs[operator_name]
+    
+    #Remove a particular catalog whose operator name matches the one provided
+    def remove_catalog(self, operator_name):
+        #Sanity check whether the catalog exists for the provided operator name
+        if not operator_name in self.catalogs.keys():
+            raise CatalogError(f"Catalog not found for operator {operator_name}")
+        
+        #Remove the catalog
+        return self.catalogs.pop(operator_name)
+    
+    #Writes the operator catalog in its current state to a provided directory path
+    def write_catalogs(self, directory):
+        #Sanity check whether the path provided is a directory
+        if not os.path.isdir(directory):
+            raise CatalogError(f"The provided path is not a directory: {directory}")
+        
+        #Sanity check whether there exist catalogs to write
+        if len(self.catalogs.keys() == 0):
+            raise CatalogError(f"There are currently no catalogs to write")
+        
+        #If there exist catalogs to write, then loop through the catalogs
+        for operator_name in self.catalogs.keys():
+            #Make sure there exists a subdirectory of the provided directory that is the operator name
+            if not os.path.exists(f"{directory}/{operator_name}"):
+                os.mkdir(f"{directory}/{operator_name}")
+            #If the subdirectory of this name already exists, then make sure it's a directory
+            else:
+                if not os.path.isdir(f"{directory}/{operator_name}"):
+                    raise CatalogError(f"The catalog path already exists and is not a directory: {directory}/{operator_name}")
+            
+            #Write the catalog for this operator to its respective operator subdirectory
+            catalog = self.catalogs[operator_name]
+            catalog.write_new_dir(f"{directory}/{operator_name}")
+    
+    #Details the entire operator catalog as a string
+    def __str__(self):
+        ret = ''
+        for operator_name in self.catalogs.keys():
+            ret += f'{operator_name}: {str(self.catalogs[operator_name])}'
+        return ret

--- a/operator_csv_libs/catalog.py
+++ b/operator_csv_libs/catalog.py
@@ -232,8 +232,13 @@ class OperatorCatalog:
         
         #If the operator catalog path does exist, then loop through its subdirectories
         for subdirectory in os.listdir(path):
-            if os.path.isdir(subdirectory):
-                self.add_catalog_from_directory(f"{path}/{subdirectory}")
+            if os.path.isdir(f"{path}/{subdirectory}"):
+                #If the directory only contains one file, then attempt to load the catalog from the file
+                files = os.listdir(f"{path}/{subdirectory}")
+                if len(files) == 1:
+                    self.add_catalog_from_file(f"{path}/{subdirectory}/{files[0]}")
+                else:
+                    self.add_catalog_from_directory(f"{path}/{subdirectory}")
     
     #Add a new catalog into the operator catalog by loading it from a file
     def add_catalog_from_file(self, path):

--- a/operator_csv_libs/catalog.py
+++ b/operator_csv_libs/catalog.py
@@ -295,7 +295,7 @@ class OperatorCatalog:
     #Get a particular catalog whose operator name matches the one provided
     def get_catalog(self, operator_name):
         #Sanity check whether the catalog exists for the provided operator name
-        if operator_name in self.catalogs.keys():
+        if operator_name not in self.catalogs.keys():
             raise CatalogError(f"Catalog not found for operator {operator_name}")
         
         #Return the catalog

--- a/operator_csv_libs/catalog.py
+++ b/operator_csv_libs/catalog.py
@@ -304,7 +304,7 @@ class OperatorCatalog:
     #Remove a particular catalog whose operator name matches the one provided
     def remove_catalog(self, operator_name):
         #Sanity check whether the catalog exists for the provided operator name
-        if not operator_name in self.catalogs.keys():
+        if operator_name not in self.catalogs.keys():
             raise CatalogError(f"Catalog not found for operator {operator_name}")
         
         #Remove the catalog

--- a/operator_csv_libs/tests/catalog_test.py
+++ b/operator_csv_libs/tests/catalog_test.py
@@ -82,6 +82,30 @@ BUNDLES = [
 }
 ]
 
+BUNDLE_061 = {
+    "schema": "olm.bundle",
+    "name": "etcdoperator-community.v0.6.1",
+    "package": "etcd",
+    "image": "docker.io/anik120/etcd:latest",
+    "properties": [
+        {
+            "type": "olm.gvk",
+            "value": {
+                "group": "etcd.database.coreos.com",
+                "kind": "EtcdCluster",
+                "version": "v1beta2"
+            }
+        },
+        {
+            "type": "olm.package",
+            "value": {
+                "packageName": "etcd",
+                "version": "0.6.1"
+            }
+        }
+    ]
+}
+
 class TestCatalog(unittest.TestCase):
 
     def setUp(self):
@@ -97,9 +121,27 @@ class TestCatalog(unittest.TestCase):
         self.assertEqual(self.catalog.channels, self.catalog.get_channels())
         self.assertEqual(self.catalog.get_channels(), CHANNELS)
     
+    def test_get_channels_by_substring(self):
+        #Assert the channels equal when providing a substring contained by the channel name
+        self.assertEqual(self.catalog.channels, self.catalog.get_channels_by_substring("alph"))
+        self.assertEqual(self.catalog.get_channels_by_substring("alph"), CHANNELS)
+
+        #Assert the channels do not equal when providing a substring not contained by the channel name
+        self.assertNotEqual(self.catalog.channels, self.catalog.get_channels_by_substring("beta"))
+        self.assertNotEqual(self.catalog.get_channels_by_substring("beta"), CHANNELS)
+    
     def test_get_bundles(self):
         self.assertEqual(self.catalog.get_bundles(), self.catalog.bundles)
         self.assertEqual(self.catalog.get_bundles(), BUNDLES)
+    
+    def test_get_bundles_by_substring(self):
+        #Assert the bundles equal when providing a substring contained by all the bundle names
+        self.assertEqual(self.catalog.get_bundles_by_substring('etcd'), self.catalog.bundles)
+        self.assertEqual(self.catalog.get_bundles(), BUNDLES)
+
+        #Assert one bundle is in the response when providing a substring contained only by that one, and that the other is not returned
+        self.assertIn(BUNDLE_061, self.catalog.get_bundles_by_substring('v0.6.1'))
+        self.assertNotIn(BUNDLE_061, self.catalog.get_bundles_by_substring('v0.9.4'))
 
     def test_get_default_channel(self):
         self.assertEqual(self.catalog.get_default_channel(), 'alpha')

--- a/operator_csv_libs/tests/operator_catalog_test.py
+++ b/operator_csv_libs/tests/operator_catalog_test.py
@@ -2,9 +2,6 @@ import os
 import unittest
 from ..catalog import Catalog, OperatorCatalog
 
-#Make sure the tests run in the specified order
-unittest.TestLoader.sortTestMethodsUsing = None
-
 THIS_DIR = os.path.dirname(os.path.abspath(__file__))
 
 CATALOG_1_OPERATOR_NAME = 'etcd1'
@@ -229,6 +226,12 @@ class TestOperatorCatalog(unittest.TestCase):
 
         #Assert the catalog no longer exists
         self.assertNotIn(CATALOG_2_OPERATOR_NAME, self.operatorcatalog.catalogs.keys())
+
+        #Add the catalog
+        self.operatorcatalog.add_catalog_from_directory(f"{THIS_DIR}/test_files/valid_catalogs/etcd2")
+
+        #Assert the catalog exists again
+        self.assertIn(CATALOG_2_OPERATOR_NAME, self.operatorcatalog.catalogs.keys())
     
     def test_add_catalog_from_file(self):
         #Assert the catalog does not exist
@@ -240,21 +243,32 @@ class TestOperatorCatalog(unittest.TestCase):
         #Assert the catalog does exist
         self.assertIn(CATALOG_3_OPERATOR_NAME, self.operatorcatalog.catalogs.keys())
 
-    def test_add_catalog_from_directory(self):
+        #Remove the catalog
+        self.operatorcatalog.remove_catalog(CATALOG_3_OPERATOR_NAME)
+
         #Assert the catalog does not exist
+        self.assertNotIn(CATALOG_3_OPERATOR_NAME, self.operatorcatalog.catalogs.keys())
+
+    def test_add_catalog_from_directory(self):
+        #Assert the catalog exists
+        self.assertIn(CATALOG_2_OPERATOR_NAME, self.operatorcatalog.catalogs.keys())
+
+        #Remove the catalog
+        self.operatorcatalog.remove_catalog(CATALOG_2_OPERATOR_NAME)
+
+        #Assert the catalog no longer exists
         self.assertNotIn(CATALOG_2_OPERATOR_NAME, self.operatorcatalog.catalogs.keys())
 
         #Add the catalog
         self.operatorcatalog.add_catalog_from_directory(f"{THIS_DIR}/test_files/valid_catalogs/etcd2")
 
-        #Assert the catalog exists
+        #Assert the catalog exists again
         self.assertIn(CATALOG_2_OPERATOR_NAME, self.operatorcatalog.catalogs.keys())
 
     def test_get_catalogs(self):
         #Assert all operator names are keys in the response of the get_catalogs function
         self.assertIn(CATALOG_1_OPERATOR_NAME, self.operatorcatalog.get_catalogs().keys())
         self.assertIn(CATALOG_2_OPERATOR_NAME, self.operatorcatalog.get_catalogs().keys())
-        self.assertIn(CATALOG_3_OPERATOR_NAME, self.operatorcatalog.get_catalogs().keys())
 
         #Assert all catalogs equal their respective expected values in the response of the get_catalogs function
         self.assertEqual(self.operatorcatalog.get_catalogs()[CATALOG_1_OPERATOR_NAME].package, CATALOG_1_PACKAGE)
@@ -263,9 +277,6 @@ class TestOperatorCatalog(unittest.TestCase):
         self.assertEqual(self.operatorcatalog.get_catalogs()[CATALOG_2_OPERATOR_NAME].package, CATALOG_2_PACKAGE)
         self.assertCountEqual(self.operatorcatalog.get_catalogs()[CATALOG_2_OPERATOR_NAME].channels, CATALOG_2_CHANNELS)
         self.assertCountEqual(self.operatorcatalog.get_catalogs()[CATALOG_2_OPERATOR_NAME].bundles, CATALOG_2_BUNDLES)
-        self.assertEqual(self.operatorcatalog.get_catalogs()[CATALOG_3_OPERATOR_NAME].package, CATALOG_3_PACKAGE)
-        self.assertCountEqual(self.operatorcatalog.get_catalogs()[CATALOG_3_OPERATOR_NAME].channels, CATALOG_3_CHANNELS)
-        self.assertCountEqual(self.operatorcatalog.get_catalogs()[CATALOG_3_OPERATOR_NAME].bundles, CATALOG_3_BUNDLES)
     
     def test_get_catalogs_by_substring(self):
         #Assert catalog 1 is a key in the response when searching for catalog 1, but not catalog 2
@@ -275,20 +286,18 @@ class TestOperatorCatalog(unittest.TestCase):
         #Assert all catalogs are keys when searching for the more general catalog 3 substring (etcd)
         self.assertIn(CATALOG_1_OPERATOR_NAME, self.operatorcatalog.get_catalogs_by_substring(CATALOG_3_OPERATOR_NAME).keys())
         self.assertIn(CATALOG_2_OPERATOR_NAME, self.operatorcatalog.get_catalogs_by_substring(CATALOG_3_OPERATOR_NAME).keys())
-        self.assertIn(CATALOG_3_OPERATOR_NAME, self.operatorcatalog.get_catalogs_by_substring(CATALOG_3_OPERATOR_NAME).keys())
 
         #Assert no catalogs are in the response when searching by a substring that exists in none of their names
         self.assertNotIn(CATALOG_1_OPERATOR_NAME, self.operatorcatalog.get_catalogs_by_substring("I am not a substring of any operator name").keys())
         self.assertNotIn(CATALOG_2_OPERATOR_NAME, self.operatorcatalog.get_catalogs_by_substring("I am not a substring of any operator name").keys())
-        self.assertNotIn(CATALOG_3_OPERATOR_NAME, self.operatorcatalog.get_catalogs_by_substring("I am not a substring of any operator name").keys())
 
-        #Assert catalog 3 equals its respective expected values in the response of the get_catalogs_by_substring function
-        self.assertEqual(self.operatorcatalog.get_catalogs_by_substring(CATALOG_3_OPERATOR_NAME)[CATALOG_3_OPERATOR_NAME].package, CATALOG_3_PACKAGE)
-        self.assertCountEqual(self.operatorcatalog.get_catalogs_by_substring(CATALOG_3_OPERATOR_NAME)[CATALOG_3_OPERATOR_NAME].channels, CATALOG_3_CHANNELS)
-        self.assertCountEqual(self.operatorcatalog.get_catalogs_by_substring(CATALOG_3_OPERATOR_NAME)[CATALOG_3_OPERATOR_NAME].bundles, CATALOG_3_BUNDLES)
+        #Assert catalog 1 equals its respective expected values in the response of the get_catalogs_by_substring function
+        self.assertEqual(self.operatorcatalog.get_catalogs_by_substring(CATALOG_1_OPERATOR_NAME)[CATALOG_1_OPERATOR_NAME].package, CATALOG_1_PACKAGE)
+        self.assertCountEqual(self.operatorcatalog.get_catalogs_by_substring(CATALOG_1_OPERATOR_NAME)[CATALOG_1_OPERATOR_NAME].channels, CATALOG_1_CHANNELS)
+        self.assertCountEqual(self.operatorcatalog.get_catalogs_by_substring(CATALOG_1_OPERATOR_NAME)[CATALOG_1_OPERATOR_NAME].bundles, CATALOG_1_BUNDLES)
     
     def test_get_catalog(self):
         #Assert catalog 1 equals its respective expected values in the response of the get_catalog function
-        self.assertEqual(self.operatorcatalog.get_catalogs(CATALOG_1_OPERATOR_NAME).package, CATALOG_1_PACKAGE)
-        self.assertCountEqual(self.operatorcatalog.get_catalogs(CATALOG_1_OPERATOR_NAME).channels, CATALOG_1_CHANNELS)
-        self.assertCountEqual(self.operatorcatalog.get_catalogs(CATALOG_1_OPERATOR_NAME).bundles, CATALOG_1_BUNDLES)
+        self.assertEqual(self.operatorcatalog.get_catalog(CATALOG_1_OPERATOR_NAME).package, CATALOG_1_PACKAGE)
+        self.assertCountEqual(self.operatorcatalog.get_catalog(CATALOG_1_OPERATOR_NAME).channels, CATALOG_1_CHANNELS)
+        self.assertCountEqual(self.operatorcatalog.get_catalog(CATALOG_1_OPERATOR_NAME).bundles, CATALOG_1_BUNDLES)

--- a/operator_csv_libs/tests/operator_catalog_test.py
+++ b/operator_csv_libs/tests/operator_catalog_test.py
@@ -2,6 +2,9 @@ import os
 import unittest
 from ..catalog import Catalog, OperatorCatalog
 
+#Make sure the tests run in the specified order
+unittest.TestLoader.sortTestMethodsUsing = None
+
 THIS_DIR = os.path.dirname(os.path.abspath(__file__))
 
 CATALOG_1_OPERATOR_NAME = 'etcd1'

--- a/operator_csv_libs/tests/operator_catalog_test.py
+++ b/operator_csv_libs/tests/operator_catalog_test.py
@@ -1,0 +1,291 @@
+import os
+import unittest
+from ..catalog import Catalog, OperatorCatalog
+
+THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+
+CATALOG_1_OPERATOR_NAME = 'etcd1'
+CATALOG_2_OPERATOR_NAME = 'etcd2'
+CATALOG_3_OPERATOR_NAME = 'etcd'
+
+CATALOG_1_PACKAGE = {
+    "schema": "olm.package",
+    "name": "etcd1",
+    "defaultChannel": "alpha"
+}
+
+CATALOG_1_CHANNELS = [{
+    "schema": "olm.channel",
+    "name": "alpha",
+    "package": "etcd1",
+    "entries": [
+        {"name":"etcdoperator-community.v0.6.1"},
+        {"name":"etcdoperator-community.v0.9.4", "replaces":"etcdoperator-community.v0.6.1"},
+    ]
+}]
+
+CATALOG_1_BUNDLES = [
+{
+    "schema": "olm.bundle",
+    "name": "etcdoperator-community.v0.6.1",
+    "package": "etcd1",
+    "image": "docker.io/anik120/etcd:latest",
+    "properties": [
+        {
+            "type": "olm.gvk",
+            "value": {
+                "group": "etcd.database.coreos.com",
+                "kind": "EtcdCluster",
+                "version": "v1beta2"
+            }
+        },
+        {
+            "type": "olm.package",
+            "value": {
+                "packageName": "etcd1",
+                "version": "0.6.1"
+            }
+        }
+    ]
+},
+{
+    "schema": "olm.bundle",
+    "name": "etcdoperator-community.v0.9.4",
+    "package": "etcd1",
+    "image": "docker.io/anik120/etcd:v0.9.4",
+    "properties": [
+        {
+            "type": "olm.gvk",
+            "value": {
+                "group": "etcd.database.coreos.com",
+                "kind": "EtcdCluster",
+                "version": "v1beta2"
+            }
+        },
+        {
+            "type": "olm.package",
+            "value": {
+                "packageName": "etcd1",
+                "version": "0.9.4"
+            }
+        }
+    ]
+}
+]
+
+CATALOG_2_PACKAGE = {
+    "schema": "olm.package",
+    "name": "etcd2",
+    "defaultChannel": "alpha"
+}
+
+CATALOG_2_CHANNELS = [{
+    "schema": "olm.channel",
+    "name": "alpha",
+    "package": "etcd2",
+    "entries": [
+        {"name":"etcdoperator-community.v0.6.1"},
+        {"name":"etcdoperator-community.v0.9.4", "replaces":"etcdoperator-community.v0.6.1"},
+    ]
+}]
+
+CATALOG_2_BUNDLES = [
+{
+    "schema": "olm.bundle",
+    "name": "etcdoperator-community.v0.6.1",
+    "package": "etcd2",
+    "image": "docker.io/anik120/etcd:latest",
+    "properties": [
+        {
+            "type": "olm.gvk",
+            "value": {
+                "group": "etcd.database.coreos.com",
+                "kind": "EtcdCluster",
+                "version": "v1beta2"
+            }
+        },
+        {
+            "type": "olm.package",
+            "value": {
+                "packageName": "etcd2",
+                "version": "0.6.1"
+            }
+        }
+    ]
+},
+{
+    "schema": "olm.bundle",
+    "name": "etcdoperator-community.v0.9.4",
+    "package": "etcd2",
+    "image": "docker.io/anik120/etcd:v0.9.4",
+    "properties": [
+        {
+            "type": "olm.gvk",
+            "value": {
+                "group": "etcd.database.coreos.com",
+                "kind": "EtcdCluster",
+                "version": "v1beta2"
+            }
+        },
+        {
+            "type": "olm.package",
+            "value": {
+                "packageName": "etcd2",
+                "version": "0.9.4"
+            }
+        }
+    ]
+}
+]
+
+CATALOG_3_PACKAGE = {
+    "schema": "olm.package",
+    "name": "etcd",
+    "defaultChannel": "alpha"
+}
+
+CATALOG_3_CHANNELS = [{
+    "schema": "olm.channel",
+    "name": "alpha",
+    "package": "etcd",
+    "entries": [
+        {"name":"etcdoperator-community.v0.6.1"},
+        {"name":"etcdoperator-community.v0.9.4", "replaces":"etcdoperator-community.v0.6.1"},
+    ]
+}]
+
+CATALOG_3_BUNDLES = [
+{
+    "schema": "olm.bundle",
+    "name": "etcdoperator-community.v0.6.1",
+    "package": "etcd",
+    "image": "docker.io/anik120/etcd:latest",
+    "properties": [
+        {
+            "type": "olm.gvk",
+            "value": {
+                "group": "etcd.database.coreos.com",
+                "kind": "EtcdCluster",
+                "version": "v1beta2"
+            }
+        },
+        {
+            "type": "olm.package",
+            "value": {
+                "packageName": "etcd",
+                "version": "0.6.1"
+            }
+        }
+    ]
+},
+{
+    "schema": "olm.bundle",
+    "name": "etcdoperator-community.v0.9.4",
+    "package": "etcd",
+    "image": "docker.io/anik120/etcd:v0.9.4",
+    "properties": [
+        {
+            "type": "olm.gvk",
+            "value": {
+                "group": "etcd.database.coreos.com",
+                "kind": "EtcdCluster",
+                "version": "v1beta2"
+            }
+        },
+        {
+            "type": "olm.package",
+            "value": {
+                "packageName": "etcd",
+                "version": "0.9.4"
+            }
+        }
+    ]
+}
+]
+
+class TestOperatorCatalog(unittest.TestCase):
+
+    def setUp(self):
+        self.operatorcatalog = OperatorCatalog(path=f"{THIS_DIR}/test_files/valid_catalogs")
+
+    def test_init(self):
+        #Assert that both catalog 1 and catalog 2 are read in (but not catalog 3 as we will add that in from a file later)
+        self.assertEqual(self.operatorcatalog.catalogs[CATALOG_1_OPERATOR_NAME].package, CATALOG_1_PACKAGE)
+        self.assertEqual(self.operatorcatalog.catalogs[CATALOG_1_OPERATOR_NAME].channels, CATALOG_1_CHANNELS)
+        self.assertEqual(self.operatorcatalog.catalogs[CATALOG_1_OPERATOR_NAME].bundles, CATALOG_1_BUNDLES)
+        self.assertEqual(self.operatorcatalog.catalogs[CATALOG_2_OPERATOR_NAME].package, CATALOG_2_PACKAGE)
+        self.assertEqual(self.operatorcatalog.catalogs[CATALOG_2_OPERATOR_NAME].channels, CATALOG_2_CHANNELS)
+        self.assertEqual(self.operatorcatalog.catalogs[CATALOG_2_OPERATOR_NAME].bundles, CATALOG_2_BUNDLES)
+
+    def test_remove_catalog(self):
+        #Assert the catalog exists
+        self.assertIn(CATALOG_2_OPERATOR_NAME, self.operatorcatalog.catalogs.keys())
+
+        #Remove the catalog
+        self.operatorcatalog.remove_catalog(CATALOG_2_OPERATOR_NAME)
+
+        #Assert the catalog no longer exists
+        self.assertNotIn(CATALOG_2_OPERATOR_NAME, self.operatorcatalog.catalogs.keys())
+    
+    def test_add_catalog_from_file(self):
+        #Assert the catalog does not exist
+        self.assertNotIn(CATALOG_3_OPERATOR_NAME, self.operatorcatalog.catalogs.keys())
+
+        #Add the catalog
+        self.operatorcatalog.add_catalog_from_file(f"{THIS_DIR}/test_files/valid_catalog.json")
+
+        #Assert the catalog does exist
+        self.assertIn(CATALOG_3_OPERATOR_NAME, self.operatorcatalog.catalogs.keys())
+
+    def test_add_catalog_from_directory(self):
+        #Assert the catalog does not exist
+        self.assertNotIn(CATALOG_2_OPERATOR_NAME, self.operatorcatalog.catalogs.keys())
+
+        #Add the catalog
+        self.operatorcatalog.add_catalog_from_directory(f"{THIS_DIR}/test_files/valid_catalogs/etcd2")
+
+        #Assert the catalog exists
+        self.assertIn(CATALOG_2_OPERATOR_NAME, self.operatorcatalog.catalogs.keys())
+
+    def test_get_catalogs(self):
+        #Assert all operator names are keys in the response of the get_catalogs function
+        self.assertIn(CATALOG_1_OPERATOR_NAME, self.operatorcatalog.get_catalogs().keys())
+        self.assertIn(CATALOG_2_OPERATOR_NAME, self.operatorcatalog.get_catalogs().keys())
+        self.assertIn(CATALOG_3_OPERATOR_NAME, self.operatorcatalog.get_catalogs().keys())
+
+        #Assert all catalogs equal their respective expected values in the response of the get_catalogs function
+        self.assertEqual(self.operatorcatalog.get_catalogs()[CATALOG_1_OPERATOR_NAME].package, CATALOG_1_PACKAGE)
+        self.assertEqual(self.operatorcatalog.get_catalogs()[CATALOG_1_OPERATOR_NAME].channels, CATALOG_1_CHANNELS)
+        self.assertEqual(self.operatorcatalog.get_catalogs()[CATALOG_1_OPERATOR_NAME].bundles, CATALOG_1_BUNDLES)
+        self.assertEqual(self.operatorcatalog.get_catalogs()[CATALOG_2_OPERATOR_NAME].package, CATALOG_2_PACKAGE)
+        self.assertEqual(self.operatorcatalog.get_catalogs()[CATALOG_2_OPERATOR_NAME].channels, CATALOG_2_CHANNELS)
+        self.assertEqual(self.operatorcatalog.get_catalogs()[CATALOG_2_OPERATOR_NAME].bundles, CATALOG_2_BUNDLES)
+        self.assertEqual(self.operatorcatalog.get_catalogs()[CATALOG_3_OPERATOR_NAME].package, CATALOG_3_PACKAGE)
+        self.assertEqual(self.operatorcatalog.get_catalogs()[CATALOG_3_OPERATOR_NAME].channels, CATALOG_3_CHANNELS)
+        self.assertEqual(self.operatorcatalog.get_catalogs()[CATALOG_3_OPERATOR_NAME].bundles, CATALOG_3_BUNDLES)
+    
+    def test_get_catalogs_by_substring(self):
+        #Assert catalog 1 is a key in the response when searching for catalog 1, but not catalog 2
+        self.assertIn(CATALOG_1_OPERATOR_NAME, self.operatorcatalog.get_catalogs_by_substring(CATALOG_1_OPERATOR_NAME).keys())
+        self.assertNotIn(CATALOG_2_OPERATOR_NAME, self.operatorcatalog.get_catalogs_by_substring(CATALOG_1_OPERATOR_NAME).keys())
+
+        #Assert all catalogs are keys when searching for the more general catalog 3 substring (etcd)
+        self.assertIn(CATALOG_1_OPERATOR_NAME, self.operatorcatalog.get_catalogs_by_substring(CATALOG_3_OPERATOR_NAME).keys())
+        self.assertIn(CATALOG_2_OPERATOR_NAME, self.operatorcatalog.get_catalogs_by_substring(CATALOG_3_OPERATOR_NAME).keys())
+        self.assertIn(CATALOG_3_OPERATOR_NAME, self.operatorcatalog.get_catalogs_by_substring(CATALOG_3_OPERATOR_NAME).keys())
+
+        #Assert no catalogs are in the response when searching by a substring that exists in none of their names
+        self.assertNotIn(CATALOG_1_OPERATOR_NAME, self.operatorcatalog.get_catalogs_by_substring("I am not a substring of any operator name").keys())
+        self.assertNotIn(CATALOG_2_OPERATOR_NAME, self.operatorcatalog.get_catalogs_by_substring("I am not a substring of any operator name").keys())
+        self.assertNotIn(CATALOG_3_OPERATOR_NAME, self.operatorcatalog.get_catalogs_by_substring("I am not a substring of any operator name").keys())
+
+        #Assert catalog 3 equals its respective expected values in the response of the get_catalogs_by_substring function
+        self.assertEqual(self.operatorcatalog.get_catalogs_by_substring(CATALOG_3_OPERATOR_NAME)[CATALOG_3_OPERATOR_NAME].package, CATALOG_3_PACKAGE)
+        self.assertEqual(self.operatorcatalog.get_catalogs_by_substring(CATALOG_3_OPERATOR_NAME)[CATALOG_3_OPERATOR_NAME].channels, CATALOG_3_CHANNELS)
+        self.assertEqual(self.operatorcatalog.get_catalogs_by_substring(CATALOG_3_OPERATOR_NAME)[CATALOG_3_OPERATOR_NAME].bundles, CATALOG_3_BUNDLES)
+    
+    def test_get_catalog(self):
+        #Assert catalog 1 equals its respective expected values in the response of the get_catalog function
+        self.assertEqual(self.operatorcatalog.get_catalogs(CATALOG_1_OPERATOR_NAME).package, CATALOG_1_PACKAGE)
+        self.assertEqual(self.operatorcatalog.get_catalogs(CATALOG_1_OPERATOR_NAME).channels, CATALOG_1_CHANNELS)
+        self.assertEqual(self.operatorcatalog.get_catalogs(CATALOG_1_OPERATOR_NAME).bundles, CATALOG_1_BUNDLES)

--- a/operator_csv_libs/tests/operator_catalog_test.py
+++ b/operator_csv_libs/tests/operator_catalog_test.py
@@ -211,11 +211,11 @@ class TestOperatorCatalog(unittest.TestCase):
     def test_init(self):
         #Assert that both catalog 1 and catalog 2 are read in (but not catalog 3 as we will add that in from a file later)
         self.assertEqual(self.operatorcatalog.catalogs[CATALOG_1_OPERATOR_NAME].package, CATALOG_1_PACKAGE)
-        self.assertEqual(self.operatorcatalog.catalogs[CATALOG_1_OPERATOR_NAME].channels, CATALOG_1_CHANNELS)
-        self.assertEqual(self.operatorcatalog.catalogs[CATALOG_1_OPERATOR_NAME].bundles, CATALOG_1_BUNDLES)
+        self.assertCountEqual(self.operatorcatalog.catalogs[CATALOG_1_OPERATOR_NAME].channels, CATALOG_1_CHANNELS)
+        self.assertCountEqual(self.operatorcatalog.catalogs[CATALOG_1_OPERATOR_NAME].bundles, CATALOG_1_BUNDLES)
         self.assertEqual(self.operatorcatalog.catalogs[CATALOG_2_OPERATOR_NAME].package, CATALOG_2_PACKAGE)
-        self.assertEqual(self.operatorcatalog.catalogs[CATALOG_2_OPERATOR_NAME].channels, CATALOG_2_CHANNELS)
-        self.assertEqual(self.operatorcatalog.catalogs[CATALOG_2_OPERATOR_NAME].bundles, CATALOG_2_BUNDLES)
+        self.assertCountEqual(self.operatorcatalog.catalogs[CATALOG_2_OPERATOR_NAME].channels, CATALOG_2_CHANNELS)
+        self.assertCountEqual(self.operatorcatalog.catalogs[CATALOG_2_OPERATOR_NAME].bundles, CATALOG_2_BUNDLES)
 
     def test_remove_catalog(self):
         #Assert the catalog exists
@@ -255,14 +255,14 @@ class TestOperatorCatalog(unittest.TestCase):
 
         #Assert all catalogs equal their respective expected values in the response of the get_catalogs function
         self.assertEqual(self.operatorcatalog.get_catalogs()[CATALOG_1_OPERATOR_NAME].package, CATALOG_1_PACKAGE)
-        self.assertEqual(self.operatorcatalog.get_catalogs()[CATALOG_1_OPERATOR_NAME].channels, CATALOG_1_CHANNELS)
-        self.assertEqual(self.operatorcatalog.get_catalogs()[CATALOG_1_OPERATOR_NAME].bundles, CATALOG_1_BUNDLES)
+        self.assertCountEqual(self.operatorcatalog.get_catalogs()[CATALOG_1_OPERATOR_NAME].channels, CATALOG_1_CHANNELS)
+        self.assertCountEqual(self.operatorcatalog.get_catalogs()[CATALOG_1_OPERATOR_NAME].bundles, CATALOG_1_BUNDLES)
         self.assertEqual(self.operatorcatalog.get_catalogs()[CATALOG_2_OPERATOR_NAME].package, CATALOG_2_PACKAGE)
-        self.assertEqual(self.operatorcatalog.get_catalogs()[CATALOG_2_OPERATOR_NAME].channels, CATALOG_2_CHANNELS)
-        self.assertEqual(self.operatorcatalog.get_catalogs()[CATALOG_2_OPERATOR_NAME].bundles, CATALOG_2_BUNDLES)
+        self.assertCountEqual(self.operatorcatalog.get_catalogs()[CATALOG_2_OPERATOR_NAME].channels, CATALOG_2_CHANNELS)
+        self.assertCountEqual(self.operatorcatalog.get_catalogs()[CATALOG_2_OPERATOR_NAME].bundles, CATALOG_2_BUNDLES)
         self.assertEqual(self.operatorcatalog.get_catalogs()[CATALOG_3_OPERATOR_NAME].package, CATALOG_3_PACKAGE)
-        self.assertEqual(self.operatorcatalog.get_catalogs()[CATALOG_3_OPERATOR_NAME].channels, CATALOG_3_CHANNELS)
-        self.assertEqual(self.operatorcatalog.get_catalogs()[CATALOG_3_OPERATOR_NAME].bundles, CATALOG_3_BUNDLES)
+        self.assertCountEqual(self.operatorcatalog.get_catalogs()[CATALOG_3_OPERATOR_NAME].channels, CATALOG_3_CHANNELS)
+        self.assertCountEqual(self.operatorcatalog.get_catalogs()[CATALOG_3_OPERATOR_NAME].bundles, CATALOG_3_BUNDLES)
     
     def test_get_catalogs_by_substring(self):
         #Assert catalog 1 is a key in the response when searching for catalog 1, but not catalog 2
@@ -281,11 +281,11 @@ class TestOperatorCatalog(unittest.TestCase):
 
         #Assert catalog 3 equals its respective expected values in the response of the get_catalogs_by_substring function
         self.assertEqual(self.operatorcatalog.get_catalogs_by_substring(CATALOG_3_OPERATOR_NAME)[CATALOG_3_OPERATOR_NAME].package, CATALOG_3_PACKAGE)
-        self.assertEqual(self.operatorcatalog.get_catalogs_by_substring(CATALOG_3_OPERATOR_NAME)[CATALOG_3_OPERATOR_NAME].channels, CATALOG_3_CHANNELS)
-        self.assertEqual(self.operatorcatalog.get_catalogs_by_substring(CATALOG_3_OPERATOR_NAME)[CATALOG_3_OPERATOR_NAME].bundles, CATALOG_3_BUNDLES)
+        self.assertCountEqual(self.operatorcatalog.get_catalogs_by_substring(CATALOG_3_OPERATOR_NAME)[CATALOG_3_OPERATOR_NAME].channels, CATALOG_3_CHANNELS)
+        self.assertCountEqual(self.operatorcatalog.get_catalogs_by_substring(CATALOG_3_OPERATOR_NAME)[CATALOG_3_OPERATOR_NAME].bundles, CATALOG_3_BUNDLES)
     
     def test_get_catalog(self):
         #Assert catalog 1 equals its respective expected values in the response of the get_catalog function
         self.assertEqual(self.operatorcatalog.get_catalogs(CATALOG_1_OPERATOR_NAME).package, CATALOG_1_PACKAGE)
-        self.assertEqual(self.operatorcatalog.get_catalogs(CATALOG_1_OPERATOR_NAME).channels, CATALOG_1_CHANNELS)
-        self.assertEqual(self.operatorcatalog.get_catalogs(CATALOG_1_OPERATOR_NAME).bundles, CATALOG_1_BUNDLES)
+        self.assertCountEqual(self.operatorcatalog.get_catalogs(CATALOG_1_OPERATOR_NAME).channels, CATALOG_1_CHANNELS)
+        self.assertCountEqual(self.operatorcatalog.get_catalogs(CATALOG_1_OPERATOR_NAME).bundles, CATALOG_1_BUNDLES)

--- a/operator_csv_libs/tests/test_files/valid_catalogs/etcd1/catalog.json
+++ b/operator_csv_libs/tests/test_files/valid_catalogs/etcd1/catalog.json
@@ -1,0 +1,60 @@
+{
+    "schema": "olm.package",
+    "name": "etcd1",
+    "defaultChannel": "alpha"
+}
+{
+    "schema": "olm.bundle",
+    "name": "etcdoperator-community.v0.6.1",
+    "package": "etcd1",
+    "image": "docker.io/anik120/etcd:latest",
+    "properties": [
+        {
+            "type": "olm.gvk",
+            "value": {
+                "group": "etcd.database.coreos.com",
+                "kind": "EtcdCluster",
+                "version": "v1beta2"
+            }
+        },
+        {
+            "type": "olm.package",
+            "value": {
+                "packageName": "etcd1",
+                "version": "0.6.1"
+            }
+        }
+    ]
+}
+{
+    "schema": "olm.bundle",
+    "name": "etcdoperator-community.v0.9.4",
+    "package": "etcd1",
+    "image": "docker.io/anik120/etcd:v0.9.4",
+    "properties": [
+        {
+            "type": "olm.gvk",
+            "value": {
+                "group": "etcd.database.coreos.com",
+                "kind": "EtcdCluster",
+                "version": "v1beta2"
+            }
+        },
+        {
+            "type": "olm.package",
+            "value": {
+                "packageName": "etcd1",
+                "version": "0.9.4"
+            }
+        }
+    ]
+}
+{
+    "schema": "olm.channel",
+    "name": "alpha",
+    "package": "etcd1",
+    "entries": [
+        {"name":"etcdoperator-community.v0.6.1"},
+        {"name":"etcdoperator-community.v0.9.4", "replaces":"etcdoperator-community.v0.6.1"}
+    ]
+}

--- a/operator_csv_libs/tests/test_files/valid_catalogs/etcd2/olm.bundle-etcdoperator-community.v0.6.1.json
+++ b/operator_csv_libs/tests/test_files/valid_catalogs/etcd2/olm.bundle-etcdoperator-community.v0.6.1.json
@@ -1,0 +1,23 @@
+{
+    "schema": "olm.bundle",
+    "name": "etcdoperator-community.v0.6.1",
+    "package": "etcd2",
+    "image": "docker.io/anik120/etcd:latest",
+    "properties": [
+        {
+            "type": "olm.gvk",
+            "value": {
+                "group": "etcd.database.coreos.com",
+                "kind": "EtcdCluster",
+                "version": "v1beta2"
+            }
+        },
+        {
+            "type": "olm.package",
+            "value": {
+                "packageName": "etcd2",
+                "version": "0.6.1"
+            }
+        }
+    ]
+}

--- a/operator_csv_libs/tests/test_files/valid_catalogs/etcd2/olm.bundle-etcdoperator-community.v0.9.4.json
+++ b/operator_csv_libs/tests/test_files/valid_catalogs/etcd2/olm.bundle-etcdoperator-community.v0.9.4.json
@@ -1,0 +1,23 @@
+{
+    "schema": "olm.bundle",
+    "name": "etcdoperator-community.v0.9.4",
+    "package": "etcd2",
+    "image": "docker.io/anik120/etcd:v0.9.4",
+    "properties": [
+        {
+            "type": "olm.gvk",
+            "value": {
+                "group": "etcd.database.coreos.com",
+                "kind": "EtcdCluster",
+                "version": "v1beta2"
+            }
+        },
+        {
+            "type": "olm.package",
+            "value": {
+                "packageName": "etcd2",
+                "version": "0.9.4"
+            }
+        }
+    ]
+}

--- a/operator_csv_libs/tests/test_files/valid_catalogs/etcd2/olm.channel-alpha.json
+++ b/operator_csv_libs/tests/test_files/valid_catalogs/etcd2/olm.channel-alpha.json
@@ -1,0 +1,9 @@
+{
+    "schema": "olm.channel",
+    "name": "alpha",
+    "package": "etcd2",
+    "entries": [
+        {"name":"etcdoperator-community.v0.6.1"},
+        {"name":"etcdoperator-community.v0.9.4", "replaces":"etcdoperator-community.v0.6.1"}
+    ]
+}

--- a/operator_csv_libs/tests/test_files/valid_catalogs/etcd2/olm.package-etcd2.json
+++ b/operator_csv_libs/tests/test_files/valid_catalogs/etcd2/olm.package-etcd2.json
@@ -1,0 +1,5 @@
+{
+    "schema": "olm.package",
+    "name": "etcd2",
+    "defaultChannel": "alpha"
+}


### PR DESCRIPTION
In this PR, I update the `Catalog` object to contain "search by substring" functions.  In addition, I introduce the `OperatorCatalog` object which acts as an aggregation of `Catalog` objects, with support for reading in a catalog, writing a catalog to a directory, and more.