### PR TITLE
Update catalog remove functions and constructor

### DIFF
--- a/operator_csv_libs/catalog.py
+++ b/operator_csv_libs/catalog.py
@@ -2,6 +2,7 @@ import os
 import sys
 import logging
 import json
+from operator import itemgetter
 from natsort import natsorted
 
 # Setup logging to stdout
@@ -40,7 +41,14 @@ class Catalog:
             self._load_catalog_from_json_stream_file(file)
         #Read in data from a directory of json files
         elif os.path.isdir(file):
-            self._load_catalog_from_directory(file)
+            #Detect whether there is just one, or multiple files in the directory
+            #If there is just one file in the directory, chances are it's a catalog.json
+            #Therefore, in this case we try to load it from the file instead of the directory
+            files_in_dir = os.listdir(file)
+            if len(files_in_dir) == 1:
+                self._load_catalog_from_json_stream_file(f"{file}/{files_in_dir[0]}")
+            else:
+                self._load_catalog_from_directory(file)
 
     #Load the Catalog object using a single json stream file
     def _load_catalog_from_json_stream_file(self, file):
@@ -110,6 +118,18 @@ class Catalog:
                 #Read in an olm bundle object
                 elif data['schema'] == 'olm.bundle':
                     self.bundles.append(data)
+    
+    #Get the latest channel using natsort
+    def _get_latest_channel(self):
+        #Sanity check whether the channels are empty, in which case retern None
+        if len(self.channels) == 0:
+            return None
+        
+        #Natsort the channels by their name
+        sorted_channels = natsorted(self.channels, key=itemgetter(*['name']))
+
+        #Return the most up-to-date channel based on natsort result
+        return sorted_channels[-1]
 
     def get_channels(self):
         return self.channels
@@ -172,17 +192,33 @@ class Catalog:
             with open(f"{directory}/olm.bundle-{b['name']}.json", 'w') as bundle_file:
                 json.dump(b, bundle_file, indent=self.indent)
 
+    #Remove a channel and all bundles that it contains
     def remove_channel(self, channel):
+        #Loop through the channels and check to see if the provided channel name matches the found channel name
         for c in self.channels:
             if c['name'] == channel:
+                #If so, first remove all the bundles it contains
                 for e in c['entries']:
                     self.remove_bundle(e['name'])
+                #Then, remove the channel
                 self.channels.remove(c)
+                #Finally, if the channel is the current default channel, update the default channel automatically
+                if channel == self.get_default_channel():
+                    self.set_default_channel(self._get_latest_channel())
 
+    #Remove a bundle, and if that bundle is contained in a channel, remove it from the channel as well
     def remove_bundle(self, name):
-        for b in self.bundles:
-            if b['name'] == name:
-                self.bundles.remove(b)
+        #Loop through all bundles in the object
+        for bundle in self.bundles:
+            #If the desired bundle is found, then proceed to remove it
+            if bundle['name'] == name:
+                #First determine if the bundle is contained in any channels, and remove its reference there
+                for channel in self.channels:
+                    for entry in channel['entries']:
+                        if bundle['name'] == entry['name']:
+                            channel['entries'].remove(entry)
+                #Then, remove the bundle itself
+                self.bundles.remove(bundle)
 
     def add_channel(self, channel, package):
         self.channels.append({


### PR DESCRIPTION
In this PR, I update the "remove" functions to contain more sophisticated logic.  I also slightly updated the constructor to operate in a bit more sophisticated of a manner so that fewer exceptions are encountered when toggling between old and new FBC formats.  In particular, here are my changes.

- Update constructor so that if it is presented with a directory, it checks whether that directory contains only one file, in which case it assumes this file is a single `catalog.json` stream
- Add a `_get_latest_channel` private function that uses `natsort` to get the latest channel currently stored by the object
- Update remove bundle function to remove the bundle reference from any channels it belongs to before removing the bundle
- Update remove channel function to auto-update the default channel to the latest if the current default is removed