### PR TITLE
Enable copying channels and bundles between catalogs

### DIFF
--- a/operator_csv_libs/catalog.py
+++ b/operator_csv_libs/catalog.py
@@ -148,15 +148,14 @@ class Catalog:
         #Return the list of channels matching the substring
         return channels_matching_substring
     
-    #Get a single channel matching a provided string, throw an exception if not found
+    #Get a single channel matching a provided string, return none if not found
     def get_channel(self, channel):
-        #Find the channel, and if not found, throw an exception
+        #Find the channel, and if not found, return none
         retrieved_channel = None
         for ch in self.channels:
             if ch['name'] == channel:
                 retrieved_channel = ch
-        if retrieved_channel == None:
-            raise CatalogError(f"Channel {channel} not found in catalog {self.package['name']}")
+                break
         
         #If it is found, return the channel
         return retrieved_channel
@@ -178,15 +177,14 @@ class Catalog:
         #Return the list of bundles matching the substring
         return bundles_matching_substring
     
-    #Get a single bundle matching a provided string, throw an exception if not found
+    #Get a single bundle matching a provided string, return none if not found
     def get_bundle(self, bundle):
-        #Find the bundle, and if not found, throw an exception
+        #Find the bundle, and if not found, return none
         retrieved_bundle = None
         for b in self.bundles:
             if b['name'] == bundle:
                 retrieved_bundle = b
-        if retrieved_bundle == None:
-            raise CatalogError(f"Bundle {bundle} not found in catalog {self.package['name']}")
+                break
         
         #If it is found, return the channel
         return retrieved_bundle
@@ -197,12 +195,17 @@ class Catalog:
     def get_channel_and_bundles(self, channel):
         #Get the channel matching the provided channel name
         channel = self.get_channel(channel)
+
+        #If channel is not found then return none
+        if channel == None:
+            return None
         
         #If channel exists, then retrieve all its bundles
         bundles = []
         for entry in channel['entries']:
             bundle = self.get_bundle(entry['name'])
-            bundles.append(bundle)
+            if bundle != None:
+                bundles.append(bundle)
         
         #After retrieving all bundles corresponding to the channel, return the formatted dict
         return { 'channel' : channel, 'bundles' : bundles }
@@ -328,17 +331,38 @@ class Catalog:
     #It expects the same format as is returned by the get_channel_and_bundles function
     def add_channel_and_bundles(self, channel_and_bundles):
         #Sanity check on the channel and bundles input parameters
+        if channel_and_bundles == None: #Added since the get_channel_and_bundles function can return None now
+            raise CatalogError("The provided channel and bundles parameter was None")
         if 'channel' not in channel_and_bundles.keys():
             raise CatalogError("No channel was provided")
+        if 'name' not in channel_and_bundles['channel'].keys():
+            raise CatalogError("The provided channel was unnamed")
         if 'bundles' not in channel_and_bundles.keys():
             raise CatalogError("No bundles were provided")
+        
+        #Sanity check on channel before appending
+        for channel in self.channels:
+            if channel['name'] == channel_and_bundles['channel']['name']:
+                raise CatalogError(f"Channel already exists: {channel_and_bundles['channel']['name']}")
         
         #Add the channel to the catalog along with its entries
         self.channels.append(channel_and_bundles['channel'])
 
         #Add the bundles corresponding to the channel entries into the catalog
         for bundle in channel_and_bundles['bundles']:
-            self.bundles.append(bundle)
+            #Sanity check that the bundle is named
+            if 'name' not in bundle.keys():
+                raise CatalogError("A provided bundle was unnamed")
+            
+            #Sanity check that the bundle doesn't already exist
+            bundle_exists = False
+            for b in self.bundles:
+                if b['name'] == bundle['name']:
+                    bundle_exists = True
+            
+            #If it doesn't already exist, then append it
+            if not bundle_exists:
+                self.bundles.append(bundle)
 
     def get_latest_channel_entry(self, channel):
         names = [e['name'] for e in channel['entries'] ]

--- a/operator_csv_libs/catalog.py
+++ b/operator_csv_libs/catalog.py
@@ -148,6 +148,19 @@ class Catalog:
         #Return the list of channels matching the substring
         return channels_matching_substring
     
+    #Get a single channel matching a provided string, throw an exception if not found
+    def get_channel(self, channel):
+        #Find the channel, and if not found, throw an exception
+        retrieved_channel = None
+        for ch in self.channels:
+            if ch['name'] == channel:
+                retrieved_channel = ch
+        if retrieved_channel == None:
+            raise CatalogError(f"Channel {channel} not found in catalog {self.package['name']}")
+        
+        #If it is found, return the channel
+        return retrieved_channel
+    
     def get_bundles(self):
         return self.bundles
 
@@ -164,6 +177,35 @@ class Catalog:
         
         #Return the list of bundles matching the substring
         return bundles_matching_substring
+    
+    #Get a single bundle matching a provided string, throw an exception if not found
+    def get_bundle(self, bundle):
+        #Find the bundle, and if not found, throw an exception
+        retrieved_bundle = None
+        for b in self.bundles:
+            if b['name'] == bundle:
+                retrieved_bundle = b
+        if retrieved_bundle == None:
+            raise CatalogError(f"Bundle {bundle} not found in catalog {self.package['name']}")
+        
+        #If it is found, return the channel
+        return retrieved_bundle
+
+    #Function returns a formatted dict containing a channel and its corresponding bundles
+    #The output of this function can be plugged into the add_channel_and_bundles function
+    #in order to add a channel and its corresponding bundles from one catalog to another
+    def get_channel_and_bundles(self, channel):
+        #Get the channel matching the provided channel name
+        channel = self.get_channel(channel)
+        
+        #If channel exists, then retrieve all its bundles
+        bundles = []
+        for entry in channel['entries']:
+            bundle = self.get_bundle(entry['name'])
+            bundles.append(bundle)
+        
+        #After retrieving all bundles corresponding to the channel, return the formatted dict
+        return { 'channel' : channel, 'bundles' : bundles }
 
     def get_default_channel(self):
         return self.package['defaultChannel']
@@ -281,7 +323,23 @@ class Catalog:
                 if 'entries' in c:
                     c['entries'] = []
                 c['entries'].append(data)
-                
+    
+    #This function adds a channel and bundles from a formatted dict that is provided as a parameter
+    #It expects the same format as is returned by the get_channel_and_bundles function
+    def add_channel_and_bundles(self, channel_and_bundles):
+        #Sanity check on the channel and bundles input parameters
+        if 'channel' not in channel_and_bundles.keys():
+            raise CatalogError("No channel was provided")
+        if 'bundles' not in channel_and_bundles.keys():
+            raise CatalogError("No bundles were provided")
+        
+        #Add the channel to the catalog along with its entries
+        self.channels.append(channel_and_bundles['channel'])
+
+        #Add the bundles corresponding to the channel entries into the catalog
+        for bundle in channel_and_bundles['bundles']:
+            self.bundles.append(bundle)
+
     def get_latest_channel_entry(self, channel):
         names = [e['name'] for e in channel['entries'] ]
         names = natsorted(names)

--- a/operator_csv_libs/tests/catalog_test.py
+++ b/operator_csv_libs/tests/catalog_test.py
@@ -174,8 +174,8 @@ class TestCatalog(unittest.TestCase):
         self.assertEqual(BUNDLES, self.catalog.get_channel_and_bundles('alpha')['bundles'])
     
     def test_add_channel_and_bundles(self):
-        #Get alpha channel and bundles and store as variable
-        channel_and_bundles = self.catalog.get_channel_and_bundles('alpha')
+        #Get alpha channel and bundles and copy into a variable
+        channel_and_bundles = self.catalog.get_channel_and_bundles('alpha').copy()
 
         #Remove alpha channel (removes bundles as well), ignoring the exception it will throw since alpha is the last channel
         try:

--- a/operator_csv_libs/tests/catalog_test.py
+++ b/operator_csv_libs/tests/catalog_test.py
@@ -1,5 +1,6 @@
 import os
 import unittest
+import copy
 from ..catalog import Catalog, CatalogError
 
 THIS_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -175,7 +176,7 @@ class TestCatalog(unittest.TestCase):
     
     def test_add_channel_and_bundles(self):
         #Get alpha channel and bundles and copy into a variable
-        channel_and_bundles = self.catalog.get_channel_and_bundles('alpha').copy()
+        channel_and_bundles = copy.deepcopy(self.catalog.get_channel_and_bundles('alpha'))
 
         #Remove alpha channel (removes bundles as well), ignoring the exception it will throw since alpha is the last channel
         try:

--- a/operator_csv_libs/tests/catalog_test.py
+++ b/operator_csv_libs/tests/catalog_test.py
@@ -177,8 +177,11 @@ class TestCatalog(unittest.TestCase):
         #Get alpha channel and bundles and store as variable
         channel_and_bundles = self.catalog.get_channel_and_bundles('alpha')
 
-        #Remove alpha channel (removes bundles as well)
-        self.catalog.remove_channel('alpha')
+        #Remove alpha channel (removes bundles as well), ignoring the exception it will throw since alpha is the last channel
+        try:
+            self.catalog.remove_channel('alpha')
+        except CatalogError as ce:
+            pass
 
         #Assert alpha channel and bundles have been removed
         self.assertEqual(self.catalog.get_channel_and_bundles('alpha'), None)

--- a/operator_csv_libs/tests/catalog_test.py
+++ b/operator_csv_libs/tests/catalog_test.py
@@ -144,7 +144,7 @@ class TestCatalog(unittest.TestCase):
         self.assertEqual(self.catalog.get_channel("alpha"), CHANNELS[0])
 
         #Assert that an exception is thrown when the beta channel (which doesn't exist) is searched for
-        self.assertRaises(CatalogError, self.catalog.get_channel("beta"))
+        self.assertRaises(CatalogError, self.catalog.get_channel, 'beta')
     
     def test_get_bundles(self):
         self.assertEqual(self.catalog.get_bundles(), self.catalog.bundles)
@@ -164,7 +164,7 @@ class TestCatalog(unittest.TestCase):
         self.assertEqual(BUNDLE_061, self.catalog.get_bundle('etcdoperator-community.v0.6.1'))
 
         #Assert an exception is returned when searching for the 0.6.2 channel (doesn't exist)
-        self.assertRaises(CatalogError, self.catalog.get_bundle('etcdoperator-community.v0.6.2'))
+        self.assertRaises(CatalogError, self.catalog.get_bundle, 'etcdoperator-community.v0.6.2')
     
     def test_get_channel_and_bundles(self):
         #Assert that the alpha channel is returned under the channel key
@@ -181,7 +181,7 @@ class TestCatalog(unittest.TestCase):
         self.catalog.remove_channel('alpha')
 
         #Assert alpha channel and bundles have been removed
-        self.assertRaises(CatalogError, self.catalog.get_channel_and_bundles('alpha'))
+        self.assertRaises(CatalogError, self.catalog.get_channel_and_bundles, 'alpha')
 
         #Add alpha channel and bundles
         self.catalog.add_channel_and_bundles(channel_and_bundles)

--- a/operator_csv_libs/tests/catalog_test.py
+++ b/operator_csv_libs/tests/catalog_test.py
@@ -143,8 +143,8 @@ class TestCatalog(unittest.TestCase):
         #Assert the alpha channel is returned when getting the alpha channel by its name
         self.assertEqual(self.catalog.get_channel("alpha"), CHANNELS[0])
 
-        #Assert that an exception is thrown when the beta channel (which doesn't exist) is searched for
-        self.assertRaises(CatalogError, self.catalog.get_channel, 'beta')
+        #Assert that None is returned when the beta channel (which doesn't exist) is searched for
+        self.assertEqual(self.catalog.get_channel("beta"), None)
     
     def test_get_bundles(self):
         self.assertEqual(self.catalog.get_bundles(), self.catalog.bundles)
@@ -163,8 +163,8 @@ class TestCatalog(unittest.TestCase):
         #Assert the 0.6.1 bundle returned when searching for it by name
         self.assertEqual(BUNDLE_061, self.catalog.get_bundle('etcdoperator-community.v0.6.1'))
 
-        #Assert an exception is returned when searching for the 0.6.2 channel (doesn't exist)
-        self.assertRaises(CatalogError, self.catalog.get_bundle, 'etcdoperator-community.v0.6.2')
+        #Assert None is returned when searching for the 0.6.2 channel (doesn't exist)
+        self.assertEqual(self.catalog.get_bundle('etcdoperator-community.v0.6.2'), None)
     
     def test_get_channel_and_bundles(self):
         #Assert that the alpha channel is returned under the channel key
@@ -181,7 +181,7 @@ class TestCatalog(unittest.TestCase):
         self.catalog.remove_channel('alpha')
 
         #Assert alpha channel and bundles have been removed
-        self.assertRaises(CatalogError, self.catalog.get_channel_and_bundles, 'alpha')
+        self.assertEqual(self.catalog.get_channel_and_bundles('alpha'), None)
 
         #Add alpha channel and bundles
         self.catalog.add_channel_and_bundles(channel_and_bundles)


### PR DESCRIPTION
In this PR, I update the Catalog object to allow for channels and bundles to easily be copied from one to another, assuming they both have a valid structure.