### PR TITLE
Update `dohq-artifactory` version in the operator-csv-libs base image

### DIFF
--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -1,6 +1,6 @@
 pyyaml==6.0
 pygithub==1.55
-dohq-artifactory==0.7.574
+dohq-artifactory==0.8.4
 requests==2.27.1
 pytest==7.1.3
 httpretty==1.1.2


### PR DESCRIPTION
In this PR, I update the `operator-csv-libs` base image's requirements.txt file to require version `0.8.4` of `dohq-artifactory`