### PR TITLE
Bump PyYAML to fixed patch level

### DIFF
--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -1,4 +1,4 @@
-pyyaml==6.0
+pyyaml==6.0.1
 pygithub==1.55
 dohq-artifactory==0.8.4
 requests==2.27.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 requests==2.28.1
-pyyaml==6.0
+pyyaml==6.0.1
 pygithub==1.55
 dohq-artifactory==0.8.4
 pytest==7.1.3

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     packages=['operator_csv_libs'],
     install_requires=[
         'requests==2.28.1',
-        'pyyaml==6.0',
+        'pyyaml==6.0.1',
         'pygithub==1.55',
         'dohq-artifactory==0.8.4',
         'natsort==8.3.1'


### PR DESCRIPTION
`PyYAML<6.0.1` was causing our `pip install` to fail due to the following issue:
> This issue was caused by an incompatibility of PyYAML<6.0.1 compiled under the version of Cython>=3.0, released on [July 17, 2023](https://github.com/cython/cython/releases/tag/3.0.0).
This has now been fixed by [a new release of PyYAML, tagged 6.0.1](https://github.com/yaml/pyyaml/releases/tag/6.0.1).

For reference see:
https://stackoverflow.com/questions/76708329/docker-compose-no-longer-building-image-attributeerror-cython-sources