### PR TITLE
fix: update requests to 2.32.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-requests==2.28.1
+requests==2.32.0
 pyyaml==6.0.1
 pygithub==1.55
 dohq-artifactory==0.8.4


### PR DESCRIPTION
In this PR, I update the `requests` package to 2.32.0 to bring in CVE fixes.